### PR TITLE
option to use "json" struct tag values as querystring param names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,79 @@
+# File created using '.gitignore Generator' for Visual Studio Code: https://bit.ly/vscode-gig
+# Created by https://www.gitignore.io/api/go,macos,visualstudiocode,sublimetext
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+# Test binary, build with `go test -c`
+*.test
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+### Go Patch ###
+/Godeps/
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+# Icon must end with two \r
+Icon
+# Thumbnails
+._*
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+### SublimeText ###
+# Cache files for Sublime Text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+# Workspace files are user-specific
+*.sublime-workspace
+# Project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using Sublime Text
+# *.sublime-project
+# SFTP configuration file
+sftp-config.json
+# Package control specific files
+Package Control.last-run
+Package Control.ca-list
+Package Control.ca-bundle
+Package Control.system-ca-bundle
+Package Control.cache/
+Package Control.ca-certs/
+Package Control.merged-ca-bundle
+Package Control.user-ca-bundle
+oscrypto-ca-bundle.crt
+bh_unicode_properties.cache
+# Sublime-github package stores a github token in this file
+# https://packagecontrol.io/packages/sublime-github
+GitHub.sublime-settings
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+# End of https://www.gitignore.io/api/go,macos,visualstudiocode,sublimetext
+# Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
+
+### emacs ###
+README.org
+*~
+
+# Goland
+.idea/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Known Issues:
 
 # uri
 
-a convenient and easy way to convert from a uri to a struct or vic-versa
+A convenient and easy way to convert from a uri to a struct or vic-versa.
 
 ## keywords
 
@@ -31,6 +31,21 @@ a convenient and easy way to convert from a uri to a struct or vic-versa
   - time.Time: time format field for marshaling of time.Time `format:"2006-01-02T15:04:05Z"`
   - rune/int32: `format:"rune"`
 
+## Other Options
+
+### Use "json" struct tag values
+You may wish to use existing "json" struct tag values instead of defining "uri" values for querystring parameter 
+names. To do so call "UseJSONTag()".
+
+```go
+package main
+
+import "github.com/jbsmith7741/uri"
+
+func main() {
+    uri.UseJSONTag()
+}
+```
 
 ## Non-Standard Query Params Support 
 
@@ -41,7 +56,8 @@ Arrays are supported by passing a comma separated list or by passing the value m
   - `?array=1&array=2&array=3&array=4`
 
 ### Maps
- maps are supported by providing the key value param into the value with a colon `:` in between them. Multiple pairs can be passed as separated params or joined with the pipe `|` 
+Maps are supported by providing the key value param into the value with a colon `:` in between them. Multiple pairs 
+can be passed as separated params or joined with the pipe `|` 
 
   - map[string]int `?map=a:1|b:2|c:3` 
   - map[int]string `?map=1:a&map=2:b&map=3:c`
@@ -50,7 +66,8 @@ Arrays are supported by passing a comma separated list or by passing the value m
 
 ## example 1
 
-If we have the uri "http://example.com/path/to/page?name=ferret&color=purple" we can unmarshal this to a predefined struct as follows
+If we have the uri "http://example.com/path/to/page?name=ferret&color=purple" we can unmarshal this to a predefined 
+struct as follows:
 
 ``` go
 type Example struct {
@@ -68,7 +85,7 @@ err := uri.Unmarshal("http://example.com/path/to/page?name=ferret&color=purple",
 }
 ```
 
-this would become the following struct
+This would become the following struct:
 
 ``` go
 e := Example{

--- a/marshal.go
+++ b/marshal.go
@@ -16,9 +16,11 @@ var (
 	mapSeparator = "|"
 
 	// supported struct tags
-	uriTag      = "uri"
-	defaultTag  = "default"
-	requiredTag = "required"
+	uriTag       = "uri"
+	defaultTag   = "default"
+	requiredTag  = "required"
+	jsonTag      = "json"
+	usingJSONTag = false
 
 	// supported tag values
 	scheme    = "scheme"
@@ -29,6 +31,14 @@ var (
 	origin    = "origin"    // scheme://host/path
 	fragment  = "fragment"  // anything after hash #
 )
+
+// UseJSONTag will use the "json" struct field tag values instead of "uri" for determining
+// the expected querystring parameter name. JSON specific struct tag options such as "omitempty" and "string" are
+// ignored.
+func UseJSONTag() {
+	uriTag = jsonTag
+	usingJSONTag = true
+}
 
 // Marshal a struct into a string representation of a uri
 // Note: Marshal panics if a struct or pointer to a struct is not provided
@@ -81,7 +91,7 @@ func parseStruct(u *url.URL, uVal *url.Values, vStruct reflect.Value) {
 		}
 		var name string
 		structTag := vStruct.Type().Field(i).Tag
-		tag := structTag.Get(uriTag)
+		tag := parseURITag(structTag.Get(uriTag))
 
 		fs := GetFieldString(field, structTag)
 

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -42,7 +42,7 @@ func Unmarshal(uri string, v interface{}) error {
 		}
 
 		name := vStruct.Type().Field(i).Name
-		tag := vStruct.Type().Field(i).Tag.Get(uriTag)
+		tag := parseURITag(vStruct.Type().Field(i).Tag.Get(uriTag))
 		if tag == "-" {
 			continue
 		}

--- a/utils.go
+++ b/utils.go
@@ -51,3 +51,13 @@ func isZero(v reflect.Value) bool {
 	z := reflect.Zero(v.Type())
 	return v.Interface() == z.Interface()
 }
+
+// parseURITag splits the passed tag value by comma and returns the first value. Comma separated values
+// is only checked when using the "json" tag as the name.
+func parseURITag(tv string) string {
+	if !usingJSONTag {
+		return tv
+	}
+
+	return strings.Split(tv, ",")[0]
+}


### PR DESCRIPTION
Allow "json" name values as option for querystring param names in place of "uri".